### PR TITLE
Header copy update and shorter distance labels

### DIFF
--- a/src/components/GalleryItem.tsx
+++ b/src/components/GalleryItem.tsx
@@ -28,7 +28,7 @@ class GalleryItem extends Component<IProps> {
           <div className="gallery__item__labels-container">
             {labels}
             {shift.distance && shift.distance !== 9999 &&
-              <Label key={-1} text={`約距 ${shift.distance.toFixed(2)} 公里`} />
+              <Label key={-1} text={`約距 ${shift.distance.toFixed(1} 公里`} />
             }
           </div>
         }

--- a/src/components/GalleryItem.tsx
+++ b/src/components/GalleryItem.tsx
@@ -28,7 +28,7 @@ class GalleryItem extends Component<IProps> {
           <div className="gallery__item__labels-container">
             {labels}
             {shift.distance && shift.distance !== 9999 &&
-              <Label key={-1} text={`約距 ${shift.distance.toFixed(1} 公里`} />
+              <Label key={-1} text={`約距 ${shift.distance.toFixed(1)} 公里`} />
             }
           </div>
         }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -6,7 +6,7 @@ export default function Navbar(props: any) {
   return (
     <nav className="navbar navbar-expand-lg navbar-light bg-light">
       <div className="container">
-        <a className="navbar-brand" href="#">兩好三壞，全台開團資訊（11月16日更新）</a>
+        <a className="navbar-brand" href="#">兩好三壞，全台開團資訊</a>
         <button
           className="navbar-toggler"
           type="button"


### PR DESCRIPTION
We no longer need last updated date.
Two-decimal distance labels caused layout imperfections.